### PR TITLE
Setup CodeCoverage analysis tool 

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -29,6 +29,6 @@ jobs:
         run: npm test -- --coverage
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@<671740ac38dd9b0130fbe1cec585b89eea48d3de>
+        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
This PR integrates Codecov into our CI workflow to automatically upload test coverage reports. This provides visibility into line and branch coverage from our unit tests and helps track coverage changes over time.
<img width="1832" height="660" alt="image" src="https://github.com/user-attachments/assets/f25de605-45ef-47c5-a457-38f0f7195606" />
