### PR TITLE
Make PostHog API key optional

### DIFF
--- a/campus-guide/.env.example
+++ b/campus-guide/.env.example
@@ -21,7 +21,7 @@ EXPO_PUBLIC_APP_SLUG=
 EXPO_PUBLIC_GOOGLE_ANDROID_CLIENT_ID=
 EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID=
 
-# PostHog – usability testing analytics & session replay
+# PostHog – optional (usability testing, surveys, session replay). Leave empty for local dev.
 EXPO_PUBLIC_POSTHOG_API_KEY=
 EXPO_PUBLIC_POSTHOG_HOST=
 

--- a/campus-guide/app/_layout.tsx
+++ b/campus-guide/app/_layout.tsx
@@ -15,6 +15,12 @@ import { ParticipantSessionProvider } from '@context/ParticipantSessionContext';
 
 const isExpoGo = Constants.appOwnership === 'expo';
 
+/** PostHogProvider requires a non-empty apiKey; use this when analytics are off. */
+const POSTHOG_DISABLED_PLACEHOLDER_KEY = 'local-dev-posthog-off';
+
+const posthogApiKey = (process.env.EXPO_PUBLIC_POSTHOG_API_KEY ?? '').trim();
+const posthogEnabled = posthogApiKey.length > 0;
+
 export {
   // Catch any errors thrown by the Layout component.
   ErrorBoundary,
@@ -57,39 +63,46 @@ export default function RootLayout() {
 function RootLayoutNav() {
   const colorScheme = useColorScheme();
 
+  const appTree = (
+    <ParticipantSessionProvider>
+      <ParticipantIdentifier>
+        <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
+          <Stack>
+            <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+            <Stack.Screen name="modal" options={{ presentation: 'modal' }} />
+            <Stack.Screen
+              name="moderator"
+              options={{ presentation: 'modal', title: 'Session setup' }}
+            />
+          </Stack>
+        </ThemeProvider>
+      </ParticipantIdentifier>
+    </ParticipantSessionProvider>
+  );
+
   return (
     <PostHogProvider
-      apiKey={process.env.EXPO_PUBLIC_POSTHOG_API_KEY!}
+      apiKey={posthogEnabled ? posthogApiKey : POSTHOG_DISABLED_PLACEHOLDER_KEY}
       options={{
+        disabled: !posthogEnabled,
         host: process.env.EXPO_PUBLIC_POSTHOG_HOST,
-        enableSessionReplay: !isExpoGo,
-        ...(!isExpoGo && {
-          sessionReplayConfig: {
-            maskAllTextInputs: false,
-            maskAllImages: false,
-            captureLog: true,
-            captureNetworkTelemetry: true,
-          },
-        }),
+        enableSessionReplay: posthogEnabled && !isExpoGo,
+        ...(posthogEnabled &&
+          !isExpoGo && {
+            sessionReplayConfig: {
+              maskAllTextInputs: false,
+              maskAllImages: false,
+              captureLog: true,
+              captureNetworkTelemetry: true,
+            },
+          }),
       }}
     >
-      {/* Required for in-app surveys on React Native (event triggers alone are not enough). */}
-      <PostHogSurveyProvider>
-        <ParticipantSessionProvider>
-          <ParticipantIdentifier>
-            <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
-              <Stack>
-                <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
-                <Stack.Screen name="modal" options={{ presentation: 'modal' }} />
-                <Stack.Screen
-                  name="moderator"
-                  options={{ presentation: 'modal', title: 'Session setup' }}
-                />
-              </Stack>
-            </ThemeProvider>
-          </ParticipantIdentifier>
-        </ParticipantSessionProvider>
-      </PostHogSurveyProvider>
+      {posthogEnabled ? (
+        <PostHogSurveyProvider>{appTree}</PostHogSurveyProvider>
+      ) : (
+        appTree
+      )}
     </PostHogProvider>
   );
 }


### PR DESCRIPTION
This pull request improves how PostHog analytics are handled in the app, making it easier to disable analytics for local development and ensuring the app works correctly when PostHog is not configured. The main changes include introducing a placeholder API key for local development, conditionally enabling analytics features, and updating the environment variable documentation.

**Analytics configuration improvements:**

* Added a `POSTHOG_DISABLED_PLACEHOLDER_KEY` and logic to use it when the PostHog API key is empty, allowing analytics to be easily disabled for local development. (`campus-guide/app/_layout.tsx`)
* Updated the `RootLayoutNav` component to conditionally enable or disable PostHog features based on the presence of a valid API key, and to only wrap the app in `PostHogSurveyProvider` when analytics are enabled. (`campus-guide/app/_layout.tsx`) [[1]](diffhunk://#diff-f69490e4f10e2e495abed9c21c07d6db4f841edef404e75f97b71d96319cf7cdL60-R66) [[2]](diffhunk://#diff-f69490e4f10e2e495abed9c21c07d6db4f841edef404e75f97b71d96319cf7cdL92-R105)

**Documentation update:**

* Clarified in `.env.example` that PostHog is optional and can be left empty for local development. (`campus-guide/.env.example`)